### PR TITLE
Compatibility with newer collectd

### DIFF
--- a/sysctl.c
+++ b/sysctl.c
@@ -243,7 +243,7 @@ static int sysctl_add_read_callback (struct sysctl_t *st)
   status = plugin_register_complex_read (/* group = */ "sysctl",
       /* name      = */ callback_name,
       /* callback  = */ sysctl_read,
-      /* interval  = */ NULL,
+      /* interval  = */ 0,
       /* user_data = */ &ud);
   return (status);
 } /* int sysctl_add_read_callback */


### PR DESCRIPTION
interval is now cdtime_t and default value is 0 instead of NULL
https://github.com/collectd/collectd/commit/cce136946b879557f91183e4de58e92b81e138c8
